### PR TITLE
Dmg Powerup, and Player Dmg Status

### DIFF
--- a/Assets/Scripts/Anti_Tryn.cs
+++ b/Assets/Scripts/Anti_Tryn.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Anti_Tryn : MonoBehaviour
+{
+    public int multiplier = 2;
+    void OnTriggerEnter2D (Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            Pickup(other);
+        }
+    }
+    void Pickup(Collider2D player)
+    {
+       
+       Strength playerScript = player.GetComponent<Strength>();
+       playerScript.decreasesDamage(multiplier);
+        Destroy(gameObject);
+    }
+}

--- a/Assets/Scripts/Anti_Tryn.cs.meta
+++ b/Assets/Scripts/Anti_Tryn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc33d634fe5814333b2fa812d076831c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Strength.cs
+++ b/Assets/Scripts/Strength.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Strength : MonoBehaviour
+{
+   public int strength = 6;
+   public int maxStrength = 12;
+  
+    
+    public void increasesDamage(int increase){
+        strength += increase;
+        if(strength >= maxStrength){
+            strength = maxStrength;
+        }
+    }
+    public void decreasesDamage(int decrease){
+        strength -= decrease;
+        if(strength <= 0){
+            strength = 1;
+        }
+    }
+
+}

--- a/Assets/Scripts/Strength.cs.meta
+++ b/Assets/Scripts/Strength.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3642ebbac87ca4465a595c95a2d5c5f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tryn_Needle.cs
+++ b/Assets/Scripts/Tryn_Needle.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor.Build;
+using UnityEngine;
+
+public class Tryn_Needle : MonoBehaviour
+{
+   
+    public int multiplier = 2;
+    void OnTriggerEnter2D (Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            Pickup(other);
+        }
+    }
+    void Pickup(Collider2D player)
+    {
+       
+       Strength playerScript = player.GetComponent<Strength>();
+       playerScript.increasesDamage(multiplier);
+        Destroy(gameObject);
+    }
+}

--- a/Assets/Scripts/Tryn_Needle.cs.meta
+++ b/Assets/Scripts/Tryn_Needle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d90057333091a4820848681a45a1c5b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a Tryn needle powerup which adds 2 dmg, a anti Tryn powerup which decreases 2 damage, and also created a new script which just clearly declares the players attack damage.